### PR TITLE
Fix!: Output refers to sensitive values

### DIFF
--- a/projects/microservices/01-currency-exchange-microservice-basic/configuration/iaac/azure/kubernetes/main.tf
+++ b/projects/microservices/01-currency-exchange-microservice-basic/configuration/iaac/azure/kubernetes/main.tf
@@ -26,6 +26,7 @@ resource "azurerm_kubernetes_cluster" "terraform-k8s" {
     name            = "agentpool"
     node_count      = var.node_count
     vm_size         = "standard_b2ms"
+    # vm_size         = "standard_d2as_v5"      CHANGE IF AN ERROR ARISES 
   }
 
   service_principal {

--- a/projects/microservices/01-currency-exchange-microservice-basic/configuration/iaac/azure/kubernetes/outputs.tf
+++ b/projects/microservices/01-currency-exchange-microservice-basic/configuration/iaac/azure/kubernetes/outputs.tf
@@ -1,27 +1,34 @@
 output "client_key" {
   value = azurerm_kubernetes_cluster.terraform-k8s.kube_config.0.client_key
+  sensitive = true
 }
 
 output "client_certificate" {
   value = azurerm_kubernetes_cluster.terraform-k8s.kube_config.0.client_certificate
+  sensitive = true
 }
 
 output "cluster_ca_certificate" {
   value = azurerm_kubernetes_cluster.terraform-k8s.kube_config.0.cluster_ca_certificate
+  sensitive = true
 }
 
 output "cluster_username" {
   value = azurerm_kubernetes_cluster.terraform-k8s.kube_config.0.username
+  sensitive = true
 }
 
 output "cluster_password" {
   value = azurerm_kubernetes_cluster.terraform-k8s.kube_config.0.password
+  sensitive = true
 }
 
 output "kube_config" {
   value = azurerm_kubernetes_cluster.terraform-k8s.kube_config_raw
+  sensitive = true
 }
 
 output "host" {
   value = azurerm_kubernetes_cluster.terraform-k8s.kube_config.0.host
+  sensitive = true
 }


### PR DESCRIPTION
Remark all outputs as sensitive to avoid the error in running:
- azure-kubernetes-cluster-iaac-pipeline
That logs: 
"Output refers to sensitive values"


![Screenshot from 2022-08-02 06-12-59](https://user-images.githubusercontent.com/22253160/182284006-f628c03a-9fa1-436a-a871-0e814c664f82.png)
