### PR TITLE
[Hotfix] Replace the deprecated Ansible module `ec2` with `ec2_instance`

### DIFF
--- a/ansible/backup/playbooks/09-create-ec2.yml
+++ b/ansible/backup/playbooks/09-create-ec2.yml
@@ -12,7 +12,7 @@
         vpc_subnet_id: subnet-75cb9912
         assign_public_ip: yes
         group: ["http_server_sg"]
-        instance_tags: {type: http, Environment: QA}
+        tags: {type: http, Environment: QA}
         wait: yes
       register: ec2_output
     - debug: var=ec2_output

--- a/ansible/backup/playbooks/09-create-ec2.yml
+++ b/ansible/backup/playbooks/09-create-ec2.yml
@@ -11,7 +11,7 @@
         count_tag: {type: http}
         vpc_subnet_id: subnet-75cb9912
         assign_public_ip: yes
-        group: ["http_server_sg"]
+        security_groups: ["http_server_sg"]
         tags: {type: http, Environment: QA}
         wait: yes
       register: ec2_output

--- a/ansible/backup/playbooks/09-create-ec2.yml
+++ b/ansible/backup/playbooks/09-create-ec2.yml
@@ -8,7 +8,8 @@
         region: us-east-1
         #count: 1
         exact_count: 2
-        count_tag: {type: http}
+        filters:
+          "tag:type": http
         vpc_subnet_id: subnet-75cb9912
         network:
           assign_public_ip: true

--- a/ansible/backup/playbooks/09-create-ec2.yml
+++ b/ansible/backup/playbooks/09-create-ec2.yml
@@ -4,7 +4,7 @@
     - ec2_instance:
         key_name: default-ec2
         instance_type: t2.micro
-        image: ami-062f7200baf2fa504
+        image_id: ami-062f7200baf2fa504
         region: us-east-1
         #count: 1
         exact_count: 2

--- a/ansible/backup/playbooks/09-create-ec2.yml
+++ b/ansible/backup/playbooks/09-create-ec2.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: localhost
   tasks:
-    - ec2:
+    - ec2_instance:
         key_name: default-ec2
         instance_type: t2.micro
         image: ami-062f7200baf2fa504

--- a/ansible/backup/playbooks/09-create-ec2.yml
+++ b/ansible/backup/playbooks/09-create-ec2.yml
@@ -10,7 +10,8 @@
         exact_count: 2
         count_tag: {type: http}
         vpc_subnet_id: subnet-75cb9912
-        assign_public_ip: yes
+        network:
+          assign_public_ip: true
         security_groups: ["http_server_sg"]
         tags: {type: http, Environment: QA}
         wait: yes


### PR DESCRIPTION
The latest amazon.aws collection version is `5.1.0`.
Based on the amazon.aws collection [release notes](https://ansible-collections.github.io/amazon.aws/branch/stable-5/collections/amazon/aws/docsite/CHANGELOG.html#id17):

> The `ec2` module has been removed in release 4.0.0 and replaced by the `ec2_instance` module

As result the playbook `09-create-ec2.yml` can not be executed.

This PR introduces the following changes: 
- Replace of the `ec2` module with `ec2_instance`
- Use new options that are compatible with the `ec2_instance` instance
